### PR TITLE
Added pure Rust RGB panel driver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,10 +25,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "argh"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab257697eb9496bf75526f0217b5ed64636a9cfafa78b8365c71bd283fcef93e"
+dependencies = [
+ "argh_derive",
+ "argh_shared",
+]
+
+[[package]]
+name = "argh_derive"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b382dbd3288e053331f03399e1db106c9fb0d8562ad62cb04859ae926f324fa6"
+dependencies = [
+ "argh_shared",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "argh_shared"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cb94155d965e3d37ffbbe7cc5b82c3dd79dd33bd48e536f73d2cfb8d85506f"
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "az"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
 
 [[package]]
 name = "base-x"
@@ -67,6 +101,12 @@ name = "bumpalo"
 version = "3.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
+
+[[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
@@ -187,10 +227,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 
 [[package]]
-name = "glob"
-version = "0.3.0"
+name = "embedded-graphics"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+checksum = "750082c65094fbcc4baf9ba31583ce9a8bb7f52cadfb96f6164b1bc7f922f32b"
+dependencies = [
+ "az",
+ "byteorder",
+ "embedded-graphics-core",
+ "float-cmp",
+ "micromath",
+]
+
+[[package]]
+name = "embedded-graphics-core"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8b1239db5f3eeb7e33e35bd10bd014e7b2537b17e071f726a09351431337cfa"
+dependencies = [
+ "az",
+ "byteorder",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1267f4ac4f343772758f7b1bdcbe767c218bbab93bb432acbf5162bbf85a6c4"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "itoa"
@@ -268,7 +340,9 @@ dependencies = [
 name = "lightsbruh"
 version = "0.1.0"
 dependencies = [
+ "argh",
  "cpal",
+ "rpi-led-panel",
 ]
 
 [[package]]
@@ -306,6 +380,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
+name = "memmap2"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b182332558b18d807c4ce1ca8ca983b34c3ee32765e47b3f0f69b90355cc1dc"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memoffset"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -313,6 +396,12 @@ checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "micromath"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc4010833aea396656c2f91ee704d51a6f1329ec2ab56ffd00bfd56f7481ea94"
 
 [[package]]
 name = "minimal-lexical"
@@ -386,9 +475,9 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "7.1.2"
+version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5507769c4919c998e69e49c839d9dc6e693ede4cc4290d6ad8b41d4f09c548c"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
@@ -476,9 +565,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff9f3fef3968a3ec5945535ed654cb38ff72d7495a25619e2247fb15a2ed9ba"
+checksum = "ba1ef8814b5c993410bb3adfad7a5ed269563e4a2f90c41f5d85be7fb47133bf"
 dependencies = [
  "cfg-if",
  "libc",
@@ -548,9 +637,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
+checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
 dependencies = [
  "regex-syntax",
 ]
@@ -560,6 +649,19 @@ name = "regex-syntax"
 version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
+
+[[package]]
+name = "rpi-led-panel"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a866312348b607ed822c20b9e5f3c1095cdfe2645763edbee7c6ca8334ff50c"
+dependencies = [
+ "argh",
+ "embedded-graphics",
+ "libc",
+ "memmap2",
+ "thread-priority",
+]
 
 [[package]]
 name = "rustc-hash"
@@ -748,6 +850,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread-priority"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978519ae4c6891352f964b88da4ab5a3a9b74a40247cda5baee145dae6cd3b71"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "log",
+ "winapi",
+]
+
+[[package]]
 name = "toml"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -888,19 +1002,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
  "windows_aarch64_gnullvm",
- "windows_aarch64_msvc 0.42.0",
- "windows_i686_gnu 0.42.0",
- "windows_i686_msvc 0.42.0",
- "windows_x86_64_gnu 0.42.0",
+ "windows_aarch64_msvc 0.42.1",
+ "windows_i686_gnu 0.42.1",
+ "windows_i686_msvc 0.42.1",
+ "windows_x86_64_gnu 0.42.1",
  "windows_x86_64_gnullvm",
- "windows_x86_64_msvc 0.42.0",
+ "windows_x86_64_msvc 0.42.1",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -910,9 +1024,9 @@ checksum = "2623277cb2d1c216ba3b578c0f3cf9cdebeddb6e66b1b218bb33596ea7769c3a"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -922,9 +1036,9 @@ checksum = "d3925fd0b0b804730d44d4b6278c50f9699703ec49bcd628020f46f4ba07d9e1"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
+checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -934,9 +1048,9 @@ checksum = "ce907ac74fe331b524c1298683efbf598bb031bc84d5e274db2083696d07c57c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -946,15 +1060,15 @@ checksum = "2babfba0828f2e6b32457d5341427dcbb577ceef556273229959ac23a10af33d"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -964,6 +1078,6 @@ checksum = "f4dd6dc7df2d84cf7b33822ed5b86318fb1781948e9663bacd047fc9dd52259d"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+argh = "0.1.10"
 cpal = "0.14.2"
+rpi-led-panel = "0.2.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,88 @@
-use cpal::traits::{HostTrait, DeviceTrait, StreamTrait};
-
 fn main() {
     println!("It's lights, bruh!");
     listen();
 }
 
+fn scale_col(value: isize, low: isize, high: isize) -> u8 {
+    if value < low {
+        return 0;
+    }
+    if value > high {
+        return 255;
+    }
+    (255 * (value - low) / (high - low)) as u8
+}
+
+fn rotate([x, y]: [isize; 2], angle: f64) -> [f64; 2] {
+    [
+        x as f64 * angle.cos() - y as f64 * angle.sin(),
+        x as f64 * angle.sin() + y as f64 * angle.cos(),
+    ]
+}
+
+fn display() {
+    use std::io::Write;
+    use rpi_led_panel::{
+        RGBMatrix,
+        RGBMatrixConfig,
+    };
+
+    let config: RGBMatrixConfig = argh::from_env();
+    let rows = config.rows as isize;
+    let cols = config.cols as isize;
+    let (mut matrix, mut canvas) = RGBMatrix::new(config, 0)
+        .expect("Matrix initialization failed");
+
+    let [center_x, center_y] = [cols / 2, rows / 2];
+
+    let rotate_square = (rows.min(cols) as f64 * 1.41) as isize;
+    let min_rotate = center_x - rotate_square / 2;
+    let max_rotate = center_x + rotate_square / 2;
+
+    let display_square = (rows.min(cols) as f64 * 0.7) as isize;
+    let min_display = center_x - display_square / 2;
+    let max_display = center_x + display_square / 2;
+
+    for step in 0.. {
+        let rotation_deg = step as f64 / 2.0;
+        for x in min_rotate..max_rotate {
+            for y in min_rotate..max_rotate {
+                let [rot_x, rot_y] =
+                    rotate([x - center_x, y - center_x], rotation_deg.to_radians());
+                let canvas_x = rot_x + center_x as f64;
+                let canvas_y = rot_y + center_y as f64;
+                if (min_display..max_display).contains(&x)
+                    && (min_display..max_display).contains(&y)
+                {
+                    canvas.set_pixel(
+                        canvas_x as usize,
+                        canvas_y as usize,
+                        scale_col(x, min_display, max_display),
+                        255 - scale_col(y, min_display, max_display),
+                        scale_col(y, min_display, max_display),
+                    )
+                } else {
+                    canvas.set_pixel(canvas_x as usize, canvas_y as usize, 0, 0, 0)
+                }
+            }
+        }
+
+        canvas = matrix.update_on_vsync(canvas);
+
+        if step % 120 == 0 {
+            print!("\r{:>100}\rFramerate: {}", "", matrix.get_framerate());
+            std::io::stdout().flush().unwrap();
+        }
+    }
+}
+
 fn listen() {
+    use cpal::traits::{
+        HostTrait,
+        DeviceTrait,
+        StreamTrait,
+    };
+
     let host = cpal::default_host();
 
     // Get the input devices.
@@ -37,7 +114,8 @@ fn listen() {
     let supported_input_configs = input_device.supported_input_configs()
         .expect("Error while querying configs!");
     for config in supported_input_configs {
-        println!("Found supported input config: {} channels, {}/{} min/max sample rate, {} sample_format.",
+        println!("Found supported input config: {} channels, \
+                {}/{} min/max sample rate, {} sample formats.",
             config.channels().to_string(), config.min_sample_rate().0, config.max_sample_rate().0,
             config.sample_format().sample_size().to_string());
     }
@@ -51,7 +129,12 @@ fn listen() {
         &supported_config.config(),
         move |data: & [i16], _: &cpal::InputCallbackInfo| {
             // React to stream events and read stream data here.
-            println!("Read some input stream data: {:?}!", data);
+            let mut sum = 0.0f32;
+            for datum in data {
+                sum += *datum as f32;
+            }
+            let average = sum / data.len() as f32;
+            println!("Read some input stream data (average): {:?}!", average);
         },
         move |_err| {
             // React to errors here.
@@ -62,6 +145,6 @@ fn listen() {
     println!("Built input stream!  Attempting to listen to input stream...");
     stream.play().expect("Unable to play stream!");
 
-    // Porkchop sandwiches!!
-    loop {}
+    // Porkchop sandwiches?!
+    display();
 }


### PR DESCRIPTION
Added a pure Rust implementation of the Raspberry Pi RGB panel driver, `rpi-led-panel`! :bulb:

I was not able to get this library to work without using pulse-width modulation (PWM), as any attempts to do so resulted in an `unreachable code` panic within the library code.  This is not so bad, because, as all the documentation mentions, PWM squeezes out the highest quality of output on the Raspberry Pi for LED panels, which results in a smoother image with less ghosting.

However, in order to use PWM with this library on my dev Rasbperry Pi and RGB Matrix HAT, I needed to:

1. Disable on-board audio to prevent a GPIO port conflict.

2. Solder a connection between pins 4 and 18 on the RGB Matrix HAT. :tophat:

To accomplish (1), I did:

```
sudo sed -i "s/^.*dtparam=audio.*$/dtparam=audio=off/g" /boot/config.txt
sudo reboot
```

After that, I was able to display the demo rotating :rainbow: square on my LED panel with:

```
sshpass -p ${PI_PASSWORD} ssh ${PI_USERNAME}@${PI_HOSTNAME}.local \
    'sudo ~/lightsbruh --pwm-lsb-nanoseconds 100 --dither-bits 2 --slowdown 0 --refresh-rate 240'
```

Note that the specific arguments that I used are not that important -- I just found that they led to a pleasing balance between high refresh rate and LED brightness :high_brightness:.  You can play around with them to find a setting that looks good to you.  Bonus points if you attach a photo-sensor over I2C to control the brightness dynamically!

Of minor note, I changed the USB audio input diagnostic output to be less spammy by simply taking the average of all of the samples read from the input audio device.  We should probably put these into a channel to send between threads at some point.

To test, I used my standard dev flow:

```
~/src/linclelinkpart5/lightsbruh add-rgb-panel*
❯ cross build
    Blocking waiting for file lock on build directory
   Compiling autocfg v1.1.0
   Compiling libc v0.2.139
   Compiling proc-macro2 v1.0.49
   Compiling quote v1.0.23
   Compiling unicode-ident v1.0.6
   Compiling syn v1.0.107
   Compiling memoffset v0.6.5
   Compiling num-traits v0.2.15
   Compiling pkg-config v0.3.26
   Compiling az v1.2.1
   Compiling alsa-sys v0.3.1
   Compiling lock_api v0.4.9
   Compiling log v0.4.17
   Compiling parking_lot_core v0.9.6
   Compiling thiserror v1.0.38
   Compiling argh_shared v0.1.10
   Compiling float-cmp v0.8.0
   Compiling nix v0.23.2
   Compiling embedded-graphics-core v0.3.3
   Compiling cpal v0.14.2
   Compiling embedded-graphics v0.7.1
   Compiling thread-priority v0.10.0
   Compiling parking_lot v0.12.1
   Compiling argh_derive v0.1.10
   Compiling thiserror-impl v1.0.38
   Compiling alsa v0.6.0
   Compiling argh v0.1.10
   Compiling memmap2 v0.5.8
   Compiling rpi-led-panel v0.2.0
   Compiling lightsbruh v0.1.0 (/project)
    Finished dev [unoptimized + debuginfo] target(s) in 29.00s

~/src/linclelinkpart5/lightsbruh add-rgb-panel* 33s
❯ sshpass -p ${PI_PASSWORD} scp -r ./target/${TARGET}/debug/lightsbruh \
    ${PI_USERNAME}@${PI_HOSTNAME}.local:~

~/src/linclelinkpart5/lightsbruh add-rgb-panel* 8s
❯ sshpass -p ${PI_PASSWORD} ssh ${PI_USERNAME}@${PI_HOSTNAME}.local \
    'sudo ~/lightsbruh --pwm-lsb-nanoseconds 100 --dither-bits 2 --slowdown 0 --refresh-rate 240'
It's lights, bruh!
ALSA lib pcm_dmix.c:1075:(snd_pcm_dmix_open) unable to open slave
ALSA lib pcm_dmix.c:1009:(snd_pcm_dmix_open) The dmix plugin supports only playback stream
ALSA lib pcm_dmix.c:1075:(snd_pcm_dmix_open) unable to open slave
ALSA lib pcm_dmix.c:1075:(snd_pcm_dmix_open) unable to open slave
ALSA lib pcm_dsnoop.c:573:(snd_pcm_dsnoop_open) The dsnoop plugin supports only capture stream
ALSA lib pcm_dmix.c:1075:(snd_pcm_dmix_open) unable to open slave
Found 6 audio input devices.
ALSA lib pcm_dmix.c:1009:(snd_pcm_dmix_open) The dmix plugin supports only playback stream
Input device: hw:CARD=Device,DEV=0.
ALSA lib pcm_dmix.c:1075:(snd_pcm_dmix_open) unable to open slave
ALSA lib pcm_dmix.c:1009:(snd_pcm_dmix_open) The dmix plugin supports only playback stream
Input device: plughw:CARD=Device,DEV=0.
ALSA lib pcm_dmix.c:1075:(snd_pcm_dmix_open) unable to open slave
Input device: default:CARD=Device.
Input device: sysdefault:CARD=Device.
ALSA lib pcm_dmix.c:1075:(snd_pcm_dmix_open) unable to open slave
Input device: front:CARD=Device,DEV=0.
ALSA lib pcm_dsnoop.c:573:(snd_pcm_dsnoop_open) The dsnoop plugin supports only capture stream
Input device: dsnoop:CARD=Device,DEV=0.
ALSA lib pcm_dmix.c:1075:(snd_pcm_dmix_open) unable to open slave
Using input device: dsnoop:CARD=Device,DEV=0.
ALSA lib pcm_dmix.c:1009:(snd_pcm_dmix_open) The dmix plugin supports only playback stream
Found supported input config: 1 channels, 48000/48000 min/max sample rate, 2 sample formats.
Built input stream!  Attempting to listen to input stream...
Framerate: 60Read some input stream data (average): -86.47829!
Read some input stream data (average): -87.39177!
Read some input stream data (average): -29.127102!
Read some input stream data (average): -34.17597!
Read some input stream data (average): -16.6599!
Read some input stream data (average): 20.214758!
...
```

And verified that a pretty rainbow spinning box was output on the display!
